### PR TITLE
chore: Update PancakeSwap IPFS CID

### DIFF
--- a/src/token-lists.json
+++ b/src/token-lists.json
@@ -7,7 +7,7 @@
     "name": "Swipe Swap",
     "homepage": "https://swipe.org"
   },
-  "https://gateway.pinata.cloud/ipfs/QmdKy1K5TMzSHncLzUXUJdvKi1tHRmJocDRfmCXxW5mshS": {
+  "https://gateway.pinata.cloud/ipfs/QmVcHQ7nHkmhSKk2pG88EA5AjC3yihaKRPQ5sskDJzmCfx": {
     "name": "PancakeSwap",
     "homepage": "https://pancakeswap.finance"
   }


### PR DESCRIPTION
Hello,

This PR update the IPFS CID for PancakeSwap default token list.
Bump version from `v2.0.1` to `v2.6.0`.

> Note: This PR originate from the `pancakeswap` GitHub organisation, in order to verify its authenticity.